### PR TITLE
Switch to "exec form" ENTRYPOINT syntax

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+build
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ FROM openjdk:8-alpine
 
 WORKDIR /sos-swim-consumer
 COPY --from=build /distribution .
-ENTRYPOINT ./bin/sos-swim-consumer
+ENTRYPOINT ["./bin/sos-swim-consumer"]
+


### PR DESCRIPTION
We were inadvertently using the "shell form" ENTRYPOINT syntax, which doesn't allow us to append command line arguments in Docker Compose. This PR switches to the "exec form" syntax, which has this property and is generally perferred.

https://docs.docker.com/engine/reference/builder/#entrypoint